### PR TITLE
Adding description meta tag

### DIFF
--- a/resources/views/layout.antlers.html
+++ b/resources/views/layout.antlers.html
@@ -5,6 +5,8 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>{{ title ?? site:name }} | {{ publication:name }}</title>
+        
+        <meta name="description" content="{{ excerpt ?? publication:description | strip_tags | safe_truncate:155:... }}" />
 
         <meta property="og:title" content="{{ title ?? site:name }} | {{ publication:name }}" />
         <meta property="og:description" content="{{ excerpt ?? publication:description | strip_tags | safe_truncate:155:... }}" />


### PR DESCRIPTION
Description meta field is missing and it's considered a good practice in Google

"Document does not have a meta description
Format your HTML in a way that enables crawlers to better understand your app’s content."

This PR fixes this.